### PR TITLE
Temporarily fix application bootstrap lifecycle if wallet is not enabled

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "vite build"
   },
   "dependencies": {
-    "@stakeordie/griptape.js": "^0.2.10",
+    "@stakeordie/griptape.js": "^0.2.11",
     "pinia": "^2.0.0-beta.2",
     "sass": "^1.35.1",
     "vue": "^3.0.5"

--- a/src/components/WalletInfo.vue
+++ b/src/components/WalletInfo.vue
@@ -4,7 +4,7 @@
     <!-- Enable wallet action -->
     <a href="#"
        class="wallet__content"
-       @click.prevent="enable"
+       @click="enable"
        v-show="!isWalletReady">
        Enable Keplr
     </a>
@@ -12,7 +12,12 @@
     <!-- Main content -->
     <div class="wallet__content" v-show="isWalletReady">
       <img src="../assets/wallet.svg" alt="wallet icon">
-      <span>{{ bech32(address) }} | {{ coinConvert(balance, 6, 'human', 2) }} SCRT</span>
+      <span v-if="!address | !balance">
+        No available, check wallet
+      </span>
+      <span v-else>
+        {{ bech32(address) }} | {{ theBalance }}
+      </span>
     </div>
 
   </div>
@@ -25,10 +30,8 @@ import { useWalletStore } from '@/modules/wallet'
 
 export default {
   methods: {
-    ...mapActions(useWalletStore, ['enable'])
-  },
+    ...mapActions(useWalletStore, ['enable']),
 
-  methods: {
     bech32,
     coinConvert
   },
@@ -38,7 +41,14 @@ export default {
       'address',
       'balance',
       'isWalletReady'
-    ])
+    ]),
+
+    theBalance() {
+      if (this.balance) {
+        return `${coinConvert(this.balance, 6, 'human', 2)} SCRT`
+      }
+      return 'No available'
+    }
   }
 }
 </script>

--- a/src/modules/wallet.js
+++ b/src/modules/wallet.js
@@ -4,13 +4,19 @@ export const useWalletStore = defineStore({
   id: 'wallet',
 
   state: () => ({
-    address: '', // current wallet address
-    balance: 0, // current balance
+    address: undefined, // current wallet address
+    balance: undefined, // current balance
     isWalletReady: false // whether the wallet is completely loaded
   }),
 
   actions: {
     async init() {
+      try {
+        this.wallet.enable()
+      } catch (e) {
+        // ignore
+      }
+
       await this.updateAccount()
 
       this.wallet.onKeplrChange(() => {
@@ -20,15 +26,18 @@ export const useWalletStore = defineStore({
 
     async updateAccount() {
       const address = await this.wallet.getAddress()
-      const account = await this.scrtClient.getAccount(address)
-      const balance = account.balance[0].amount
-      this.$patch({ address, balance, isWalletReady: true })
+      const account = await this.scrtClient?.getAccount(address)
+      if (account) {
+        const balance = account.balance[0].amount
+        this.$patch({ address, balance })
+      }
+      this.isWalletReady = true
     },
 
     async enable() {
       try {
-        await wallet.enable()
-        this.updateAccount()
+        await this.wallet.enable()
+        await this.updateAccount()
       } catch (e) {
         throw e
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,10 +84,10 @@
   dependencies:
     "@cosmjs/utils" "^0.20.0"
 
-"@stakeordie/griptape.js@^0.2.10":
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@stakeordie/griptape.js/-/griptape.js-0.2.10.tgz#7cb5088ea776375e5c12c7a045131f238120d340"
-  integrity sha512-tKg+yd8LRuSCnuEce6bnQbvteMSLY6YSPLiMq6PBDHWYeSwFC4j7whuQWnINU7UTJJOw8gJryUKITpjDcy4ooQ==
+"@stakeordie/griptape.js@^0.2.11":
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/@stakeordie/griptape.js/-/griptape.js-0.2.11.tgz#0b3f9feb5cfa784f2cb4cf0eef687c76ca6a76e2"
+  integrity sha512-9KIEpnhISi0o5dI5f/g0mA+OJ38cymisMaGMnmCrUrbmzCUOsB0vzLc1UwYVw0QwIqaXDbLQtH2TfBXZpmnu1Q==
   dependencies:
     decimal.js "^10.2.1"
     secretjs "^0.11.0"


### PR DESCRIPTION
- Upgrade @stakeordie/griptape.js to 0.2.11
- Error handling to prevent application crash when an account has zero balance
- Remove grip method to do it manually in gritape-vue.js in order to bootstrap app