### PR TITLE
Setting specific version for `pinia`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@stakeordie/griptape.js": "^0.2.13",
-    "pinia": "^2.0.0-beta.2",
+    "pinia": "2.0.0-beta.2",
     "sass": "^1.35.1",
     "vue": "^3.0.5"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stakeordie/griptape-vue.js",
-  "version": "0.2.22",
+  "version": "0.2.23",
   "license": "MIT",
   "files": [
     "dist"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "@stakeordie/griptape.js": "^0.2.13",
-    "pinia": "2.0.0-beta.2",
+    "pinia": "^2.0.0-beta.2",
     "sass": "^1.35.1",
     "vue": "^3.0.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -852,7 +852,7 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
-pinia@^2.0.0-beta.2:
+pinia@2.0.0-beta.2:
   version "2.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/pinia/-/pinia-2.0.0-beta.2.tgz#2d4321166ad77950abc35036dbefead0f0c81319"
   integrity sha512-fzjzS5gaZyWNFfQBL60Bn967Jwy3nbYuVCjzpqCCbI/wzrIN/NqLRy9ACRaZvAf+T/VEv5+A0J87UkWalSJY0w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -852,7 +852,7 @@ picomatch@^2.0.4, picomatch@^2.2.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
 
-pinia@2.0.0-beta.2:
+pinia@^2.0.0-beta.2:
   version "2.0.0-beta.2"
   resolved "https://registry.yarnpkg.com/pinia/-/pinia-2.0.0-beta.2.tgz#2d4321166ad77950abc35036dbefead0f0c81319"
   integrity sha512-fzjzS5gaZyWNFfQBL60Bn967Jwy3nbYuVCjzpqCCbI/wzrIN/NqLRy9ACRaZvAf+T/VEv5+A0J87UkWalSJY0w==


### PR DESCRIPTION
### Changelog

- Merge [PR 25](https://github.com/stakeordie/griptape-vue.js/commit/9d0542515300f89242c0445f7398cbdc33a7c7e7)
- Upgrade `pinia` version from `^2.0.0-beta.2` to `2.0.0-beta.2`